### PR TITLE
Add postcode extraction support

### DIFF
--- a/src/taskpane/components/ContactForm.tsx
+++ b/src/taskpane/components/ContactForm.tsx
@@ -7,7 +7,7 @@ import { extractSignatureBlock, parseSignature } from "./signature";
 import { getGraphToken } from "../authConfig";
 
 export function ContactForm() {
-  const [info, setInfo] = useState({ name: "", email: "", phone: "", organization: "" });
+  const [info, setInfo] = useState({ name: "", email: "", phone: "", organization: "", postcode: "" });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [statusMessage, setStatusMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
@@ -97,6 +97,13 @@ export function ContactForm() {
       <label>
         Organisatie<br />
         <Input value={info.organization} onChange={updateField("organization")} />
+      </label>
+      <br />
+      <br />
+
+      <label>
+        Postcode<br />
+        <Input value={info.postcode} onChange={updateField("postcode")} />
       </label>
       <br />
       <br />

--- a/src/taskpane/components/signature.ts
+++ b/src/taskpane/components/signature.ts
@@ -43,6 +43,14 @@ export function parseSignature(
     ? matches.reduce((a,b) => a.length >= b.length ? a : b)
     : "";
 
-  return { name, email, phone, organization };
+  // Postcode (Dutch style e.g. 1234 AB)
+  const postcodeRegex = /\b\d{4}\s?[A-Za-z]{2}\b/;
+  let postcode = "";
+  for (const line of lines) {
+    const mPost = line.match(postcodeRegex);
+    if (mPost) { postcode = mPost[0]; break; }
+  }
+
+  return { name, email, phone, organization, postcode };
 }
 

--- a/src/taskpane/graph.ts
+++ b/src/taskpane/graph.ts
@@ -39,6 +39,7 @@ export interface ContactInfo {
   email:        string;
   phone:        string;
   organization: string;
+  postcode:     string;
 }
 
 export async function createContact(token: string, info: ContactInfo): Promise<void> {
@@ -51,7 +52,8 @@ export async function createContact(token: string, info: ContactInfo): Promise<v
     givenName:       info.name,
     emailAddresses: [{ address: info.email, name: info.name }],
     businessPhones:  [ info.phone ],
-    companyName:     info.organization
+    companyName:     info.organization,
+    homeAddress:    { postalCode: info.postcode }
   };
 
   const res = await fetch("https://graph.microsoft.com/v1.0/me/contacts", {

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -41,7 +41,7 @@
           'contactInfo',
           {
             type:       Office.MailboxEnums.ItemNotificationMessageType.InformationalMessage,
-            message:    `Naam: ${info.name || '-'} | E-mail: ${info.email || '-'} | Tel: ${info.phone || '-'} | Organisatie: ${info.organization || '-'}`,
+            message:    `Naam: ${info.name || '-'} | E-mail: ${info.email || '-'} | Tel: ${info.phone || '-'} | Organisatie: ${info.organization || '-'} | Postcode: ${info.postcode || '-'}`,
             icon:       'Icon.80x80',
             persistent: false
           },
@@ -54,7 +54,8 @@
                 givenName:      info.name,
                 emailAddresses: [{ address: info.email, name: info.name }],
                 businessPhones: [ info.phone ],
-                companyName:    info.organization
+                companyName:    info.organization,
+                homeAddress:   { postalCode: info.postcode }
               };
 
               const graphRes = await fetch(
@@ -142,8 +143,16 @@
         ? matches.reduce((a, b) => a.length >= b.length ? a : b)
         : "";
 
-      // 4) Organisatie (van tevoren berekend)
-      return { name, email, phone, organization };
+      // 4) Postcode (e.g. 1234 AB)
+      const postcodeRegex = /\b\d{4}\s?[A-Za-z]{2}\b/;
+      let postcode = "";
+      for (const line of lines) {
+        const mp = line.match(postcodeRegex);
+        if (mp) { postcode = mp[0]; break; }
+      }
+
+      // 5) Organisatie (van tevoren berekend)
+      return { name, email, phone, organization, postcode };
     }
   </script>
 </head>


### PR DESCRIPTION
## Summary
- support postcode field in contact info
- extend signature parser to detect Dutch postcode
- save postcode to Graph contacts
- display and edit postcode in contact form
- show postcode in notification banner

## Testing
- `npm run lint` *(fails: office-addin-lint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be9bab5588326a6b6bbf5b7896fb5