### PR TITLE
Add folder suggestion feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "es6-promise": "^4.2.8",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
+    "string-similarity": "^4.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "regenerator-runtime": "^0.14.1"

--- a/src/taskpane/components/App.tsx
+++ b/src/taskpane/components/App.tsx
@@ -2,11 +2,66 @@
 
 import * as React from "react";
 import { useEffect, useState } from "react";
+import { findBestMatch } from "string-similarity";
 import { makeStyles } from "@fluentui/react-components";
 import { getGraphToken } from "../authConfig";
 import { getSiteAndDrive } from "../graph";
 import { getAttachments, IAttachment } from "../taskpane";
 import { ContactForm } from "./ContactForm";
+
+async function computeFolderSuggestions(
+  token: string,
+  driveId: string,
+  parentId: string,
+  fileNames: string[],
+  mailSubject: string
+): Promise<{ name: string; path: string[] }[]> {
+  const headers = { Authorization: `Bearer ${token}` };
+
+  const collect = async (
+    id: string,
+    current: string[],
+    depth: number
+  ): Promise<{ id: string; name: string; path: string[] }[]> => {
+    if (depth > 5) return [];
+    const res = await fetch(
+      `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${id}/children`,
+      { headers }
+    );
+    if (!res.ok) throw new Error(`Mappen laden faalde: ${res.status}`);
+    const data = await res.json();
+    const folders = data.value
+      .filter((it: any) => it.folder)
+      .map((it: any) => ({
+        id: it.id,
+        name: it.name,
+        path: [...current, it.id],
+      }));
+    const all = [...folders];
+    for (const f of folders) {
+      all.push(...(await collect(f.id, f.path, depth + 1)));
+    }
+    return all;
+  };
+
+  const allFolders = await collect(parentId, [parentId], 1);
+
+  const queries = [
+    ...fileNames.map(n => n.replace(/\.[^/.]+$/, "").toLowerCase()),
+    mailSubject.toLowerCase(),
+  ];
+
+  const rated = allFolders.map(f => {
+    const { bestMatch } = findBestMatch(f.name.toLowerCase(), queries);
+    return { folder: f, rating: bestMatch.rating };
+  });
+
+  return rated
+    .filter(r => r.rating >= 0.3)
+    .sort((a, b) => b.rating - a.rating)
+    .slice(0, 2)
+    .map(r => ({ name: r.folder.name, path: r.folder.path }));
+}
 
 const useStyles = makeStyles({
   root:        { minHeight: "100vh", padding: "16px", fontFamily: "Segoe UI, sans-serif" },
@@ -44,6 +99,8 @@ const App: React.FC = () => {
   const [attachments, setAttachments]         = useState<IAttachment[]>([]);
   const [selectedIds, setSelectedIds]         = useState<string[]>([]);
   const [newFolderName, setNewFolderName]     = useState<string>("");
+  const [mailSubject, setMailSubject]         = useState<string>("");
+  const [suggestions, setSuggestions] = useState<{ name: string; path: string[] }[]>([]);
 
   // Load subfolders under a parent
   const loadSubfolders = async (token: string, drive: string, parentId: string) => {
@@ -57,6 +114,27 @@ const App: React.FC = () => {
       .filter((item: any) => item.folder)
       .map((item: any) => ({ id: item.id, name: item.name }));
     setFolders(subs);
+  };
+
+  const navigateToPathIds = async (pathIds: string[]) => {
+    if (!graphToken || !driveId) return;
+    try {
+      const headers = { Authorization: `Bearer ${graphToken}` };
+      const newPath: { id: string; name: string }[] = [];
+      for (const id of pathIds) {
+        const res = await fetch(
+          `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${id}`,
+          { headers }
+        );
+        if (!res.ok) throw new Error(`Map ophalen faalde: ${res.status}`);
+        const data = await res.json();
+        newPath.push({ id: data.id, name: data.name });
+      }
+      setPath(newPath);
+      await loadSubfolders(graphToken, driveId, pathIds[pathIds.length - 1]);
+    } catch (e: any) {
+      setError("Navigeren mislukt: " + e.message);
+    }
   };
 
   // Sign in and initialize SharePoint context
@@ -184,11 +262,28 @@ const App: React.FC = () => {
           .filter(a => !a.name.toLowerCase().includes("image"))
           .map(a => a.id);
         setSelectedIds(initial);
+        const item: any = Office.context.mailbox.item;
+        setMailSubject(item?.subject || "");
       } catch (e: any) {
         setError("Kon bijlagen niet laden: " + e.message);
       }
     });
   }, []);
+
+  useEffect(() => {
+    if (!graphToken || !driveId || attachments.length === 0) return;
+    const currentId = path[path.length - 1].id;
+    const names = attachments.map(a => a.name);
+    computeFolderSuggestions(
+      graphToken,
+      driveId,
+      currentId,
+      names,
+      mailSubject
+    )
+      .then(setSuggestions)
+      .catch(e => console.error(e));
+  }, [graphToken, driveId, path, attachments, mailSubject]);
 
   return (
     <div className={styles.root}>
@@ -201,6 +296,19 @@ const App: React.FC = () => {
         </button>
       ) : (
         <>
+          {suggestions.length > 0 && (
+            <div className={styles.section}>
+              <strong>Suggestie:</strong>{" "}
+              {suggestions.map(s => (
+                <button
+                  key={s.path.join("-")}
+                  onClick={() => navigateToPathIds(s.path)}
+                >
+                  {s.name}
+                </button>
+              ))}
+            </div>
+          )}
           <div className={styles.breadcrumb}>
             {path.map((crumb, idx) => (
               <React.Fragment key={crumb.id}>


### PR DESCRIPTION
## Summary
- suggest folders based on attachment filenames and mail subject using fuzzy matching
- include "Suggestie" section with navigation buttons
- allow navigation via a new `navigateToPathIds` helper
- record mail subject
- add `string-similarity` dependency

## Testing
- `npm run lint` *(fails: office-addin-lint not found)*
- `npm run build` *(fails: webpack not found)*
- `npm run build:dev` *(fails: webpack not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules and types)*
- `npm install` *(fails: forbidden to access registry)*

------
https://chatgpt.com/codex/tasks/task_e_685c0fe7ad8c8326a0d97fa7a4da97c7