### PR TITLE
Allow fonts CDN in add-in manifest

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -17,6 +17,10 @@
   <HighResolutionIconUrl DefaultValue="https://bdf2-92-64-101-76.ngrok-free.app/assets/icon-128.png"/>
   <SupportUrl           DefaultValue="https://www.synergia.nl/help"/>
 
+  <AppDomains>
+    <AppDomain>https://res.cdn.office.net</AppDomain>
+  </AppDomains>
+
   <!-- Host & API-vereisten -->
   <Hosts><Host Name="Mailbox"/></Hosts>
   <Requirements>


### PR DESCRIPTION
## Summary
- update the Outlook add-in manifest to include the CDN used for fonts in the CSP

## Testing
- `npm run validate` *(fails: `office-addin-manifest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68629b4b19d08326b208e041b5b41d2f