### PR TITLE
Introduce BASE_URL configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BASE_URL=https://9a08-92-64-101-76.ngrok-free.app

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+BASE_URL=https://9a08-92-64-101-76.ngrok-free.app

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Outlook-Plugin
+# Outlook Plugin
+
+This project uses a configurable `BASE_URL` to define the domain for the add-in.
+The repository includes a `.env` file preconfigured with the current domain.
+If you need to change the domain, edit `.env` before building. The default is:
+
+```
+BASE_URL=https://9a08-92-64-101-76.ngrok-free.app
+```
+
+Run the build with:
+
+```bash
+npm run build
+```
+
+`BASE_URL` will be injected into `manifest.xml` and the code at build time.
+

--- a/manifest.xml
+++ b/manifest.xml
@@ -13,8 +13,8 @@
   <Description DefaultValue="Slaat bijlagen op SharePoint en extraheert contactgegevens."/>
 
   <!-- Icon & support -->
-  <IconUrl              DefaultValue="https://9a08-92-64-101-76.ngrok-free.app/assets/icon-64.png"/>
-  <HighResolutionIconUrl DefaultValue="https://9a08-92-64-101-76.ngrok-free.app/assets/icon-128.png"/>
+  <IconUrl              DefaultValue="{{BASE_URL}}/assets/icon-64.png"/>
+  <HighResolutionIconUrl DefaultValue="{{BASE_URL}}/assets/icon-128.png"/>
   <SupportUrl           DefaultValue="https://www.synergia.nl/help"/>
 
   <!-- Host & API-vereisten -->
@@ -27,7 +27,7 @@
   <FormSettings>
     <Form xsi:type="ItemRead">
       <DesktopSettings>
-        <SourceLocation DefaultValue="https://9a08-92-64-101-76.ngrok-free.app/taskpane.html"/>
+        <SourceLocation DefaultValue="{{BASE_URL}}/taskpane.html"/>
         <RequestedHeight>300</RequestedHeight>
       </DesktopSettings>
     </Form>
@@ -102,13 +102,13 @@
       <!-- 3) Resources -->
       <Resources>
         <bt:Images>
-          <bt:Image id="Icon16" DefaultValue="https://9a08-92-64-101-76.ngrok-free.app/assets/icon-16.png"/>
-          <bt:Image id="Icon32" DefaultValue="https://9a08-92-64-101-76.ngrok-free.app/assets/icon-32.png"/>
-          <bt:Image id="Icon80" DefaultValue="https://9a08-92-64-101-76.ngrok-free.app/assets/icon-80.png"/>
+          <bt:Image id="Icon16" DefaultValue="{{BASE_URL}}/assets/icon-16.png"/>
+          <bt:Image id="Icon32" DefaultValue="{{BASE_URL}}/assets/icon-32.png"/>
+          <bt:Image id="Icon80" DefaultValue="{{BASE_URL}}/assets/icon-80.png"/>
         </bt:Images>
         <bt:Urls>
-          <bt:Url id="Taskpane.Url"        DefaultValue="https://9a08-92-64-101-76.ngrok-free.app/taskpane.html"/>
-          <bt:Url id="Taskpane.UrlContact" DefaultValue="https://9a08-92-64-101-76.ngrok-free.app/taskpane.html?mode=contact"/>
+          <bt:Url id="Taskpane.Url"        DefaultValue="{{BASE_URL}}/taskpane.html"/>
+          <bt:Url id="Taskpane.UrlContact" DefaultValue="{{BASE_URL}}/taskpane.html?mode=contact"/>
         </bt:Urls>
         <bt:ShortStrings>
           <bt:String id="GroupLabel"          DefaultValue="Synergia File Saver"/>
@@ -124,7 +124,7 @@
       <!-- 4) SSO / Microsoft Graph -->
       <WebApplicationInfo>
         <Id>a4d1fb6c-f9df-4caf-a091-a2b93b078ddc</Id>
-        <Resource>api://9a08-92-64-101-76.ngrok-free.app/a4d1fb6c-f9df-4caf-a091-a2b93b078ddc</Resource>
+        <Resource>api://{{BASE_URL_HOST}}/a4d1fb6c-f9df-4caf-a091-a2b93b078ddc</Resource>
         <Scopes>
           <Scope>openid</Scope>
           <Scope>profile</Scope>

--- a/src/taskpane/authConfig.ts
+++ b/src/taskpane/authConfig.ts
@@ -1,5 +1,7 @@
 // File: src/taskpane/authConfig.ts
 
+/* global BASE_URL */
+declare const BASE_URL: string;
 import {
   PublicClientApplication,
   InteractionRequiredAuthError,
@@ -10,7 +12,7 @@ export const msalConfig = {
   auth: {
     clientId:    "a4d1fb6c-f9df-4caf-a091-a2b93b078ddc",
     authority:   "https://login.microsoftonline.com/baac284d-b86c-41d1-9728-bd7b24a4d0eb",
-    redirectUri: "https://9a08-92-64-101-76.ngrok-free.app/taskpane.html",
+    redirectUri: `${BASE_URL}/taskpane.html`,
   },
   cache: {
     cacheLocation:       "sessionStorage",


### PR DESCRIPTION
## Summary
- centralize domain with BASE_URL placeholder
- replace hard-coded URLs in `manifest.xml` and auth config
- update webpack build to inject BASE_URL and update manifest
- document BASE_URL usage and provide `.env.example`
- commit `.env` with BASE_URL=https://9a08-92-64-101-76.ngrok-free.app
- default to this base URL in webpack

## Testing
- `npm run lint` *(fails: office-addin-lint not found)*
- `npm run build` *(fails: webpack not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6863c3b198348326a674066c9c970e7a