### PR TITLE
Fix folder suggestion hook

### DIFF
--- a/src/taskpane/components/App.tsx
+++ b/src/taskpane/components/App.tsx
@@ -215,6 +215,7 @@ const App: React.FC = () => {
       setSuggestion(null);
       return undefined;
     }
+    console.log('drive tree loaded, length =', treeRef.current.length);
 
     const first = attachments.find(a => selectedIds.includes(a.id));
     if (!first) {
@@ -223,54 +224,61 @@ const App: React.FC = () => {
     }
 
     const handle = setTimeout(() => {
-      const tokens = first.name.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
-      console.debug("tokens", tokens);
+      try {
+        const tokens = first.name
+          .toLowerCase()
+          .split(/[^a-z0-9]+/)
+          .filter(Boolean);
+        console.log("tokens", tokens);
 
-      const prospects = treeRef.current.find(n => n.name === "Prospects");
-      if (!prospects) {
-        setSuggestion(null);
-        return;
-      }
-
-      const substrings: string[] = [];
-      for (let i = 0; i < tokens.length; i++) {
-        let part = tokens[i];
-        substrings.push(part);
-        for (let j = i + 1; j < tokens.length; j++) {
-          part += " " + tokens[j];
-          substrings.push(part);
+        const prospects = treeRef.current.find(n => n.name === "Prospects");
+        if (!prospects) {
+          setSuggestion(null);
+          return;
         }
-      }
 
-      let match: FolderNode | null = null;
-      let bestLen = 0;
-      let bestSub = "";
-
-      const search = (node: FolderNode) => {
-        const lname = node.path.toLowerCase();
-        for (const sub of substrings) {
-          if (lname.includes(sub) && sub.length > bestLen) {
-            bestLen = sub.length;
-            match = node;
-            bestSub = sub;
+        const substrings: string[] = [];
+        for (let i = 0; i < tokens.length; i++) {
+          let part = tokens[i];
+          substrings.push(part);
+          for (let j = i + 1; j < tokens.length; j++) {
+            part += " " + tokens[j];
+            substrings.push(part);
           }
         }
-        node.children.forEach(search);
-      };
 
-      search(prospects);
+        let match: FolderNode | null = null;
+        let bestLen = 0;
+        let bestSub = "";
 
-      if (match) {
-        console.debug("matched substring", bestSub);
-        setSuggestion(match);
-      } else {
-        console.debug("no match found, falling back to Prospects");
-        setSuggestion(prospects);
+        const search = (node: FolderNode) => {
+          const lname = node.pathNames.join("/").toLowerCase();
+          for (const sub of substrings) {
+            if (lname.includes(sub) && sub.length > bestLen) {
+              bestLen = sub.length;
+              match = node;
+              bestSub = sub;
+            }
+          }
+          node.children.forEach(search);
+        };
+
+        search(prospects);
+
+        if (match) {
+          console.log("matched substring", bestSub);
+          setSuggestion(match);
+        } else {
+          console.log("no match found, falling back to Prospects");
+          setSuggestion(prospects);
+        }
+      } catch (err) {
+        console.error(err);
       }
-    }, 200);
+    }, 20);
 
     return () => clearTimeout(handle);
-  }, [attachments, selectedIds]);
+  }, [attachments, selectedIds, driveId]);
 
   return (
     <div className={styles.root}>
@@ -285,10 +293,16 @@ const App: React.FC = () => {
         <>
           {suggestion && (
             <div
-              className="suggestion-banner"
+              className={styles.suggestion}
               onClick={() => acceptSuggestion(suggestion)}
             >
-              Save file here? <strong>{suggestion.path}</strong>
+              Save file here? <strong>{suggestion.pathNames.join('/')}</strong>
+              <span
+                className={styles.dismiss}
+                onClick={() => setSuggestion(null)}
+              >
+                ×
+              </span>
             </div>
           )}
           <div className={styles.breadcrumb}>


### PR DESCRIPTION
## Summary
- rerun suggestion hook when tree loads
- use pathNames for folder matching and show any errors in the console
- reduce delay for suggestion popup
- log tree loaded and debug output with console.log
- use Fluent UI styling for banner and show real path

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: office-addin-lint not found)*
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68643b43cab08326899d8c6931ff400f